### PR TITLE
If setting is not defined in app use settings.py as fallback

### DIFF
--- a/django_pluggableappsettings/__init__.py
+++ b/django_pluggableappsettings/__init__.py
@@ -39,7 +39,10 @@ class SettingsMetaClass(type):
         try:
             item = super(SettingsMetaClass, self).__getattribute__(item_name)
         except AttributeError:
-            raise AttributeError('The setting %s is not defined for this App' % item_name)
+            from django.conf import settings
+            item = getattr(settings, item_name, NOT_SET_VALUE)
+            if item == NOT_SET_VALUE:
+                raise AttributeError('The setting %s is not defined for this App' % item_name)
 
         if not isinstance(item, Setting):
             # we requested an item that is not a setting but still available, so we simply return it

--- a/django_pluggableappsettings/__init__.py
+++ b/django_pluggableappsettings/__init__.py
@@ -41,8 +41,9 @@ class SettingsMetaClass(type):
         except AttributeError:
             from django.conf import settings
             item = getattr(settings, item_name, NOT_SET_VALUE)
-            if item == NOT_SET_VALUE:
-                raise AttributeError('The setting %s is not defined for this App' % item_name)
+            if item != NOT_SET_VALUE:
+                return item
+            raise AttributeError('The setting %s is not defined for this App' % item_name)
 
         if not isinstance(item, Setting):
             # we requested an item that is not a setting but still available, so we simply return it


### PR DESCRIPTION
With this change you can use django-pluggableappsettings as dropin replacement for the django settings within an app. This ensures that if a setting is replaced in the app settings module that it is used. If a requested setting is missing in the app settings the AttributeError is not raised anymore and the settings file is used as fallback.